### PR TITLE
Updates to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 key.js
 node_modules
+
+#ignore intellij project
+.idea
+
+#ignore MACOS dir attributes
+.DS_Store
+
+#ignore parcel cache
+.parcel-cache


### PR DESCRIPTION
.parcel-cache can be local. More information on parcel caching: https://parceljs.org/features/development#caching

.idea is generated by intellij (webstorm, phpstorm, etc.) and can be safely ignored

.DS_store ignores system directory settings/attributes created by MACOS